### PR TITLE
Null Vs Undefined

### DIFF
--- a/src/components/app/App.tsx
+++ b/src/components/app/App.tsx
@@ -55,7 +55,7 @@ class App extends React.Component<IProps, IState> {
             isLoaded: false,
             wordList: [],
             filteredWordList: [],
-            selectedHiragana: Object.assign({}, ...Array.from(Hiragana.HiraganaSet).map((character) => ({[character]: pastSelectedHiragana[character] === null ? true : pastSelectedHiragana[character]}))),
+            selectedHiragana: Object.assign({}, ...Array.from(Hiragana.HiraganaSet).map((character) => ({[character]: pastSelectedHiragana[character] == null ? true : pastSelectedHiragana[character]}))),
             charSets: {}
         };
 


### PR DESCRIPTION
# Main Task
Fixing an issue caused by undefined being treated differently than null which was undesirable in this case. This fixes the table not loading the data correctly as all characters would be viewed as unavailable.