### PR TITLE
Page Size Selection Fix

### DIFF
--- a/src/components/app/App.tsx
+++ b/src/components/app/App.tsx
@@ -146,9 +146,11 @@ class App extends React.Component<IProps, IState> {
                                 sorting: {
                                     sortModel: [{ field: 'reading', sort: 'asc' }],
                                 },
+                                pagination: {
+                                    pageSize: 25,
+                                }
                             }}
                             disableSelectionOnClick
-                            pageSize={25}
                         />
                     </div>
                 </div>


### PR DESCRIPTION
# Main Task
Fixes an issue where only the 25 option was selectable for the number of items per page in the word table despite multiple options being visible.

## Issue Links
#16 