### PR TITLE
Deploy On Dev Changes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,10 +5,17 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'package.json'
+      - 'package-lock.json'
+      - 'tsconfig.json'
+      - 'public/**'
+      - 'src/**'
+      - '!src/resources/**.json'
 
 jobs:
   deploy:
-    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.event.pusher.name != 'github-pages')
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.event.pusher.name != 'github-actions')
 
     name: Deploy
 


### PR DESCRIPTION
# Main Task
Change the workflow to only run when dev-sensitive changes are pushed.

## Side Tasks
Made a fix to a typo which would filter on the user who pushed. This line is likely unnecessary now as the path should protect against any silliness, but will keep it in for the time being as I learn about path inclusions and exceptions.

## Issue Links
#18 