### PR TITLE
Cancel Ongoing Builds

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,10 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+
     steps:
       - name: Setup git repo
         uses: actions/checkout@v3


### PR DESCRIPTION
# Main Task
Cancel any ongoing builds/deploys to prevent funky behaviour. Unlikely to make this many pushes so close together, but might as well be safe.

## Issue Links
#17 